### PR TITLE
Refactor config to init

### DIFF
--- a/templates/gremlin-config
+++ b/templates/gremlin-config
@@ -11,4 +11,4 @@ export GREMLIN_ORG_SECRET="{{ gremlin_org_secret }}"
 
 
 # login and configure
-gremlin config --login --service "$service_name"
+gremlin init --service "$service_name"

--- a/templates/gremlin-config
+++ b/templates/gremlin-config
@@ -11,4 +11,5 @@ export GREMLIN_ORG_SECRET="{{ gremlin_org_secret }}"
 
 
 # login and configure
+# see https://help.gremlin.com/configuration/#registering-with-gremlin
 gremlin init --service "$service_name"


### PR DESCRIPTION
With gremlin 2.0.0, the `gremlin config` and `gremlin login` commands were merged into `gremlin init`.

https://help.gremlin.com/configuration/#registering-with-gremlin